### PR TITLE
Add powershell help and log file

### DIFF
--- a/sos-stig-compliant-domain-prep.ps1
+++ b/sos-stig-compliant-domain-prep.ps1
@@ -138,4 +138,4 @@ $gposDir = Join-Path $scriptPath 'Files\GPOs'
 Import-GPOs -gposDir "$gposDir"
 
 $endTime = Get-Date -Format "yyyy-MM-ddTHH:mmK"
-Add-Content -Path "$logFilePath" -Value "Finihs running script at: ${endTime}"
+Add-Content -Path "$logFilePath" -Value "Finish running script at: ${endTime}"

--- a/sos-stig-compliant-domain-prep.ps1
+++ b/sos-stig-compliant-domain-prep.ps1
@@ -1,3 +1,45 @@
+<#
+.SYNOPSIS
+
+    Create a STIG complaint domain.
+
+.DESCRIPTION
+
+    Import all the GPOs provided by SimeonOnSecurity to assist in making your
+    domain compliant with all applicable STIGs and SRGs.
+
+    Note: This script should work for most, if not all, systems without issue.
+    While @SimeonOnSecurity creates, reviews, and tests each repo intensivly,
+    we can not test every possible configuration nor does @SimeonOnSecurity
+    take any responsibility for breaking your system. If something goes wrong,
+    be prepared to submit an issue. Do not run this script if you don't
+    understand what it does.
+
+.PARAMETER logFile
+
+    File name to log the output of certain operations to, in order to enable
+    easier troubleshooting in case something doesn't work as expected. The file
+    will be created within the path where the script is located.
+
+.INPUTS
+
+    None. You cannot pipe objects into sos-stig-compliant-domain-prep.ps1.
+
+.OUTPUTS
+
+    System.String. The script outputs messages of the process and what
+                   operations it is performing.
+
+.EXAMPLE
+
+    PS> .\sos-stig-compliant-domain-prep.ps1 -logFile 'YYYYmmdd_prep.log'
+
+#>
+[CmdletBinding()]
+param (
+    [string]$logFile = 'domain_prep.log'
+)
+
 # Continue on error
 $ErrorActionPreference = 'Continue'
 
@@ -12,6 +54,11 @@ do {
 $scriptPath = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
 Set-Location $scriptPath
 
+$logFilePath = Join-Path "$scriptPath" "$logFile"
+
+$startTime = Get-Date -Format "yyyy-MM-ddTHH:mmK"
+Add-Content -Path "$logFilePath" -Value "Start running script at: ${startTime}"
+
 # Import PolicyDefinitions
 $policyDefinitionsSource = Join-Path $scriptPath 'Files\PolicyDefinitions'
 $policyDefinitionsDestination = 'C:\Windows\PolicyDefinitions'
@@ -19,8 +66,8 @@ $policyDefinitionsDestination = 'C:\Windows\PolicyDefinitions'
 try {
     Write-Output "Copying Policy Definitions to Central Store"
     # Take ownership of the PolicyDefinitions folder and grant full control to Administrators
-    takeown /f "$policyDefinitionsDestination" /r /a /d y | Out-Null
-    icacls "$policyDefinitionsDestination" /grant "Administrators:(OI)(CI)F" /t | Out-Null
+    takeown /f "$policyDefinitionsDestination" /r /a /d y | Out-File -FilePath "$logFilePath" -Append
+    icacls "$policyDefinitionsDestination" /grant "Administrators:(OI)(CI)F" /t | Out-File -FilePath "$logFilePath" -Append
     # Copy the files to the PolicyDefinitions folder
     Copy-Item -Path "$policyDefinitionsSource\*" -Destination $policyDefinitionsDestination -Force -Recurse -ErrorAction Stop
     # Get all SYSVOL paths
@@ -29,7 +76,7 @@ try {
     foreach ($sysvolPath in $sysvolPaths) {
         $policyDefinitionsSysvolDestination = Join-Path $sysvolPath.FullName 'Policies\PolicyDefinitions'
         if (!(Test-Path $policyDefinitionsSysvolDestination)) {
-            New-Item -Path $policyDefinitionsSysvolDestination -ItemType Directory -Force | Out-Null
+            New-Item -Path $policyDefinitionsSysvolDestination -ItemType Directory -Force | Out-File -FilePath "$logFilePath" -Append
         }
         Copy-Item -Path "$policyDefinitionsSource\*" -Destination $policyDefinitionsSysvolDestination -Force -Recurse
     }
@@ -40,8 +87,9 @@ catch {
 
 # Import GPOs into GPMC
 function Import-GPOs {
+    [CmdletBinding()]
     param (
-        [string]$gposDir
+        [Parameter(Mandatory=$true)][string]$gposDir
     )
 
     try {
@@ -58,19 +106,19 @@ function Import-GPOs {
             $gpoFiles = Get-ChildItem -Path $gpoCategoryDir.FullName -Directory
 
             Write-Output "Importing GPOs from $($gpoFiles.FullName)"
-    
+
             # Check if any GPO files were found
             if ($null -eq $gpoFiles) {
                 Write-Warning "No GPO files found in $($gpoFiles.FullName)"
                 continue
             }
-    
+
             foreach ($gpoFile in $gpoFiles) {
                 $gpoPath = $gpoFile.FullName
                 $gpoName = $gpoFile.BaseName
                 Write-Output "Importing $gpoName"
                 New-GPO -Name $gpoName -Comment "Created by simeononsecurity.ch"
-    
+
                 try {
                     Import-GPO -BackupGpoName $gpoName -Path $gpoPath -TargetName $gpoName -CreateIfNeeded -ErrorAction Stop
                 }
@@ -88,3 +136,6 @@ function Import-GPOs {
 # Import GPOs into GPMC
 $gposDir = Join-Path $scriptPath 'Files\GPOs'
 Import-GPOs -gposDir "$gposDir"
+
+$endTime = Get-Date -Format "yyyy-MM-ddTHH:mmK"
+Add-Content -Path "$logFilePath" -Value "Finihs running script at: ${endTime}"


### PR DESCRIPTION
A PowerShell help is added for the script so it is possible to retrieve information on the usage via the `Get-Help` cmdlet. Further, there were a couple of usages of the `Out-Null` cmdlet which hide information which can useful for troubleshooting as well as auditing purposes. 
This information is now logged to a file. 