### PR TITLE
Localization (WinGet)

### DIFF
--- a/Files/PolicyDefinitions/en-GB/DesktopAppInstaller.adml
+++ b/Files/PolicyDefinitions/en-GB/DesktopAppInstaller.adml
@@ -10,55 +10,71 @@
       <string id="EnableAppInstaller">Enable App Installer</string>
       <string id="EnableAppInstallerExplanation">This policy controls whether the Windows Package Manager can be used by users.
 
-If you enable or do not configure this setting, users will be able to use the Windows Package Manager.
+If you enable or do not configure this policy, users will be able to use the Windows Package Manager.
 
-If you disable this setting, users will not be able to use the Windows Package Manager.</string>
+If you disable this policy, users will not be able to use the Windows Package Manager.</string>
       <string id="EnableSettings">Enable App Installer Settings</string>
       <string id="EnableSettingsExplanation">This policy controls whether users can change their settings.
 
-If you enable or do not configure this setting, users will be able to change settings for the Windows Package Manager.
+If you enable or do not configure this policy, users will be able to change settings for the Windows Package Manager.
 
-If you disable this setting, users will not be able to change settings for the Windows Package Manager.</string>
+If you disable this policy, users will not be able to change settings for the Windows Package Manager.</string>
       <string id="EnableExperimentalFeatures">Enable App Installer Experimental Features</string>
       <string id="EnableExperimentalFeaturesExplanation">This policy controls whether users can enable experimental features in the Windows Package Manager.
 
-If you enable or do not configure this setting, users will be able to enable experimental features for the Windows Package Manager.
+If you enable or do not configure this policy, users will be able to enable experimental features for the Windows Package Manager.
 
-If you disable this setting, users will not be able to enable experimental features for the Windows Package Manager.</string>
+If you disable this policy, users will not be able to enable experimental features for the Windows Package Manager.</string>
       <string id="EnableLocalManifestFiles">Enable App Installer Local Manifest Files</string>
       <string id="EnableLocalManifestFilesExplanation">This policy controls whether users can install packages with local manifest files.
 
-If you enable or do not configure this setting, users will be able to install packages with local manifests using the Windows Package Manager.
+If you enable or do not configure this policy, users will be able to install packages with local manifests using the Windows Package Manager.
 
-If you disable this setting, users will not be able to install packages with local manifests using the Windows Package Manager.</string>
+If you disable this policy, users will not be able to install packages with local manifests using the Windows Package Manager.</string>
+      <string id="EnableBypassCertificatePinningForMicrosoftStore">Enable App Installer Microsoft Store Source Certificate Validation Bypass</string>
+      <string id="EnableBypassCertificatePinningForMicrosoftStoreExplanation">This policy controls whether the Windows Package Manager will validate the Microsoft Store certificate hash matches to a known Microsoft Store certificate when initiating a connection to the Microsoft Store Source. 
+
+If you enable this policy, the Windows Package Manager will bypass the Microsoft Store certificate validation. 
+
+If you disable this policy, the Windows Package Manager will validate the Microsoft Store certificate used is valid and belongs to the Microsoft Store before communicating with the Microsoft Store source. 
+
+If you do not configure this policy, the Windows Package Manager administrator settings will be adhered to.</string>
       <string id="EnableHashOverride">Enable App Installer Hash Override</string>
       <string id="EnableHashOverrideExplanation">This policy controls whether or not the Windows Package Manager can be configured to enable the ability override the SHA256 security validation in settings.
 
 If you enable or do not configure this policy, users will be able to enable the ability override the SHA256 security validation in the Windows Package Manager settings.
 
 If you disable this policy, users will not be able to enable the ability override the SHA256 security validation in the Windows Package Manager settings.</string>
+      <string id="EnableLocalArchiveMalwareScanOverride">Enable App Installer Local Archive Malware Scan Override</string>
+      <string id="EnableLocalArchiveMalwareScanOverrideExplanation">This policy controls the ability to override malware vulnerability scans when installing an archive file using a local manifest using the command line arguments.
+
+If you enable this policy, users can override the malware scan when performing a local manifest install of an archive file.
+
+If you disable this policy, users will be unable to override the malware scan of an archive file when installing using a local manifest.
+
+If you do not configure this policy, the Windows Package Manager administrator settings will be adhered to.</string>
       <string id="EnableDefaultSource">Enable App Installer Default Source</string>
       <string id="EnableDefaultSourceExplanation">This policy controls the default source included with the Windows Package Manager.
 
-If you do not configure this setting, the default source for the Windows Package Manager will be available and can be removed.
+If you do not configure this policy, the default source for the Windows Package Manager will be available and can be removed.
 
-If you enable this setting, the default source for the Windows Package Manager will be available and cannot be removed.
+If you enable this policy, the default source for the Windows Package Manager will be available and cannot be removed.
 
-If you disable this setting the default source for the Windows Package Manager will not be available.</string>
+If you disable this policy the default source for the Windows Package Manager will not be available.</string>
       <string id="EnableMicrosoftStoreSource">Enable App Installer Microsoft Store Source</string>
       <string id="EnableMicrosoftStoreSourceExplanation">This policy controls the Microsoft Store source included with the Windows Package Manager.
 
-If you do not configure this setting, the Microsoft Store source for the Windows Package manager will be available and can be removed.
+If you do not configure this policy, the Microsoft Store source for the Windows Package manager will be available and can be removed.
 
-If you enable this setting, the Microsoft Store source for the Windows Package Manager will be available and cannot be removed.
+If you enable this policy, the Microsoft Store source for the Windows Package Manager will be available and cannot be removed.
 
-If you disable this setting the Microsoft Store source for the Windows Package Manager will not be available.</string>
-      <string id="SourceAutoUpdateIntervalInMinutes">Set App Installer Source Auto Update Interval In Minutes</string>
-      <string id="SourceAutoUpdateIntervalInMinutesExplanation">This policy controls the auto update interval for package-based sources.
+If you disable this policy the Microsoft Store source for the Windows Package Manager will not be available.</string>
+      <string id="SourceAutoUpdateInterval">Set App Installer Source Auto Update Interval</string>
+      <string id="SourceAutoUpdateIntervalExplanation">This policy controls the auto update interval for package-based sources.
 
-If you disable or do not configure this setting, the default interval or the value specified in settings will be used by the Windows Package Manager.
+If you disable or do not configure this policy, the default interval or the value specified in settings will be used by the Windows Package Manager.
 
-If you enable this setting, the number of minutes specified will be used by the Windows Package Manager.</string>
+If you enable this policy, the number of minutes specified will be used by the Windows Package Manager.</string>
       <string id="EnableAdditionalSources">Enable App Installer Additional Sources</string>
       <string id="EnableAdditionalSourcesExplanation">This policy controls additional sources provided by the enterprise IT administrator.
 
@@ -75,10 +91,30 @@ If you do not configure this policy, users will be able to add or remove additio
 If you enable this policy, only the sources specified can be added or removed from the Windows Package Manager. The representation for each allowed source can be obtained from installed sources using 'winget source export'.
 
 If you disable this policy, no additional sources can be configured for the Windows Package Manager.</string>
+      <string id="EnableMSAppInstallerProtocol">Enable App Installer ms-appinstaller protocol</string>
+      <string id="EnableMSAppInstallerProtocolExplanation">This policy controls whether users can install packages from a website that is using the ms-appinstaller protocol.
+
+If you enable this policy, users will be able to install packages from websites that use this protocol.
+
+If you disable or do not configure this policy, users will not be able to install packages from websites that use this protocol.</string>
+      <string id="EnableWindowsPackageManagerCommandLineInterfaces">Enable Windows Package Manager command line interfaces</string>
+      <string id="EnableWindowsPackageManagerCommandLineInterfacesExplanation">This policy determines if a user can perform an action using the Windows Package Manager through a command line interface (WinGet CLI, or WinGet PowerShell).
+
+If you disable this policy, users will not be able execute the Windows Package Manager CLI, and PowerShell cmdlets.
+
+If you enable, or do not configure this policy, users will be able to execute the Windows Package Manager CLI commands, and PowerShell cmdlets. (Provided “Enable App Installer” policy is not disabled).
+
+This policy does not override the “Enable App Installer” policy.</string>
+      <string id="EnableWindowsPackageManagerConfiguration">Enable Windows Package Manager Configuration</string>
+      <string id="EnableWindowsPackageManagerConfigurationExplanation">This policy controls whether the Windows Package Manager configuration feature can be used by users.
+
+If you enable or do not configure this policy, users will be able to use the Windows Package Manager configuration feature.
+
+If you disable this policy, users will not be able to use the Windows Package Manager configuration feature.</string>
     </stringTable>
     <presentationTable>
-      <presentation id="SourceAutoUpdateIntervalInMinutes">
-        <decimalTextBox refId="SourceAutoUpdateIntervalInMinutes" defaultValue="5">Source Auto Update Interval In Minutes</decimalTextBox>
+      <presentation id="SourceAutoUpdateInterval">
+        <decimalTextBox refId="SourceAutoUpdateInterval" defaultValue="5">Source Auto Update Interval</decimalTextBox>
       </presentation>
       <presentation id="AdditionalSources">
         <listBox refId="AdditionalSources" required="false">Additional Sources: </listBox>


### PR DESCRIPTION
Fixes #3

Copied missing entries from en-US localization and checked for required spelling changes. Changed the term "setting" to "policy" in each object for consistency and clarity.